### PR TITLE
[FIX]: add query invalidation before workspace navigation

### DIFF
--- a/src/components/global/sidebar/index.tsx
+++ b/src/components/global/sidebar/index.tsx
@@ -32,6 +32,7 @@ import PaymentButton from '../payment-button'
 import { WORKSPACES } from '@/redux/slices/workspaces'
 import CreateWorkspaceModal from '../create-workspace/create-workspace-modal'
 import DeleteWorkspaceModal from '../delete-workspace/delete-workspace-modal'
+import { useQueryClient } from '@tanstack/react-query'
 
 type Props = {
   activeWorkspaceId: string
@@ -42,6 +43,7 @@ const Sidebar = ({ activeWorkspaceId }: Props) => {
   const router = useRouter()
   const pathName = usePathname()
   const dispatch = useDispatch()
+  const queryClient = useQueryClient()
 
   const { data, isFetched } = useQueryData(['user-workspaces'], getWorkSpaces)
   const menuItems = MENU_ITEMS(activeWorkspaceId)
@@ -54,7 +56,10 @@ const Sidebar = ({ activeWorkspaceId }: Props) => {
   const { data: workspace } = data as WorkspaceProps
   const { data: count } = notifications as NotificationProps
 
-  const onChangeActiveWorkspace = (value: string) => {
+  const onChangeActiveWorkspace = async (value: string) => {
+    // Invalidate queries before navigation
+    await queryClient.invalidateQueries({ queryKey: ['workspace-folders'] })
+    await queryClient.invalidateQueries({ queryKey: ['user-videos'] })
     router.push(`/dashboard/${value}`)
   }
   const currentWorkspace = workspace.workspace.find(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured that workspace and video data are refreshed when switching between workspaces in the sidebar, providing up-to-date information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->